### PR TITLE
Fix unpromised error in imageFromBuffer() when image is malformed

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,10 @@ function getImageData (image) {
 }
 
 function imageFromBuffer (buffer) {
-  return imageFromImageData(decodeImage(buffer))
+  return new Promise((resolve) => {
+    const imageData = decodeImage(buffer)
+    resolve(imageFromImageData(imageData))
+  })
 }
 
 function imageFromImageData (imageData) {

--- a/test.js
+++ b/test.js
@@ -518,6 +518,12 @@ const testCases = [
         global.process.removeListener('uncaughtException', handler)
       }
     }
+  },
+
+  () => {
+    // imageFromBuffer should reject the promise if the buffer is malformed
+    const malformedSrc = new Uint8Array([])
+    return imageFromBuffer(malformedSrc).catch(() => {})
   }
 ]
 


### PR DESCRIPTION
Always return a `Promise` from `imageFromImageData`.
Related issue: https://github.com/pwlmaciejewski/imghash/issues/23
